### PR TITLE
fix: correct Observe value usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,59 @@
   DD_AGENT_HOST=127.0.0.1
   DD_DOGSTATSD_PORT=8125
   ```
+
+## Usage
+
+### Server
+
+```go
+// grpc sever
+grpcSrv := grpc.NewServer(
+    grpc.Address(":9000"),
+    grpc.Middleware(
+        metrics.Server(
+          metrics.WithSeconds(statsd.NewTiming("name", statsd.WithLabels("kind", "operation"), statsd.WithClient(client))),
+          metrics.WithRequests(statsd.NewCounter("name", statsd.WithLabels("kind", "operation", "code", "reason"), statsd.WithClient(client))),
+        )
+    ),
+)
+
+// http server
+httpSrv := http.NewServer(
+    http.Address(":8000"),
+    http.Middleware(
+        metrics.Server(
+          metrics.WithSeconds(statsd.NewTiming("name", statsd.WithLabels("kind", "operation"), statsd.WithClient(client))),
+          metrics.WithRequests(statsd.NewCounter("name", statsd.WithLabels("kind", "operation", "code", "reason"), statsd.WithClient(client))),
+        )
+    ),
+)
+```
+
+### Client
+
+```go
+// grpc client
+conn, err := grpc.DialInsecure(
+    context.Background(),
+    grpc.WithEndpoint("127.0.0.1:9000"),
+    grpc.WithMiddleware(
+        metrics.Client(
+            metrics.WithSeconds(statsd.NewTiming("name", statsd.WithLabels("kind", "operation"), statsd.WithClient(client))),
+            metrics.WithRequests(statsd.NewCounter("name", statsd.WithLabels("kind", "operation", "code", "reason"), statsd.WithClient(client))),
+        ),
+    ),
+)
+
+// http client
+conn, err := http.NewClient(
+    context.Background(),
+    http.WithEndpoint("127.0.0.1:8000"),
+    http.WithMiddleware(
+        metrics.Client(
+            metrics.WithSeconds(statsd.NewTiming("name", statsd.WithLabels("kind", "operation"), statsd.WithClient(client))),
+            metrics.WithRequests(statsd.NewCounter("name", statsd.WithLabels("kind", "operation", "code", "reason"), statsd.WithClient(client))),
+        ),
+    ),
+)
+```

--- a/metrics/observer.go
+++ b/metrics/observer.go
@@ -39,5 +39,5 @@ func (d *timing) With(values ...string) metrics.Observer {
 }
 
 func (d *timing) Observe(value float64) {
-	d.opts.client.Timing(d.name, time.Duration(value)*time.Second, d.lvs, d.opts.sampleRate)
+	d.opts.client.TimeInMilliseconds(d.name, value*float64(time.Second/time.Millisecond), d.lvs, d.opts.sampleRate)
 }


### PR DESCRIPTION
The `.Second()` can't reset by `*time.Second`, 

Using `TimeInMilliseconds` with float64*1000 is ok.